### PR TITLE
REFPLTV-2489: getHostEDID(void) is not defined in devicesettings-hal-raspberrypi4

### DIFF
--- a/dsHost.c
+++ b/dsHost.c
@@ -163,3 +163,7 @@ dsError_t dsHostTerm()
 
     return ret;
 }
+
+dsError_t dsGetHostEDID(unsigned char *edid, int *length) {
+        return dsERR_OPERATION_NOT_SUPPORTED;
+}


### PR DESCRIPTION
Reason for change: Adding the mock implementation to getHostEDID
Test Procedure: build and verify.
Risks: low
Signed-off-by: Dorababu_Pragada@comcast.com