### PR TITLE
REFPLTV-2591: dsmgr crashes when rdkshell plugin is activated with test DS Hal changes

### DIFF
--- a/dsDisplay.c
+++ b/dsDisplay.c
@@ -233,7 +233,7 @@ dsError_t dsRegisterDisplayEventCallback(intptr_t handle, dsDisplayEventCallback
     	}
 	if (vDispHandle == NULL || NULL == cb)
 	{
-	    return dsERR_INVALID_PARAM;
+	    ret = dsERR_INVALID_PARAM;
 	}
 	/* Register The call Back */
 	_halcallback = cb;


### PR DESCRIPTION
Reason for change: Resolved the dsmgr crashes.
Test Procedure: build and verify the rdkshell plugin is activate.
Risks: low.
Signed-off-by: Dinesh_kumar2@comcast.com