### PR TITLE
REFPLTV-2483: org.rdk.DisplaySettings.1.getSupportedResolutions conta…

### DIFF
--- a/dsVideoResolutionSettings.h
+++ b/dsVideoResolutionSettings.h
@@ -143,20 +143,20 @@ static dsVideoPortResolution_t kResolutions[] = {
         /*.interlaced = */				_PROGRESSIVE,
     },
     {   /*1080i*/
-        /*.name = */					"1080i50",
-        /*.pixelResolution = */			dsVIDEO_PIXELRES_1920x1080,
-        /*.aspectRatio = */				dsVIDEO_ASPECT_RATIO_16x9,
-        /*.stereoscopicMode = */		dsVIDEO_SSMODE_2D,
-        /*.frameRate = */				dsVIDEO_FRAMERATE_50,
-        /*.interlaced = */				_INTERLACED,
-    },
-    {   /*1080i60*/
         /*.name = */					"1080i",
         /*.pixelResolution = */			dsVIDEO_PIXELRES_1920x1080,
         /*.aspectRatio = */				dsVIDEO_ASPECT_RATIO_16x9,
         /*.stereoscopicMode = */		dsVIDEO_SSMODE_2D,
         /*.frameRate = */				dsVIDEO_FRAMERATE_60,
         /*.interlaced = */				_INTERLACED,
+    },
+    {   /*1080i50*/
+        /*.name = */                    "1080i50",
+        /*.pixelResolution = */         dsVIDEO_PIXELRES_1920x1080,
+        /*.aspectRatio = */             dsVIDEO_ASPECT_RATIO_16x9,
+        /*.stereoscopicMode = */        dsVIDEO_SSMODE_2D,
+        /*.frameRate = */               dsVIDEO_FRAMERATE_50,
+        /*.interlaced = */              _INTERLACED,
     },
     {   /*2160p24*/
         /*.name = */                    "2160p24",

--- a/dshalUtils.c
+++ b/dshalUtils.c
@@ -49,8 +49,6 @@ const hdmiSupportedRes_t resolutionMap[] = {
     {"2160p24", 93},   // 3840x2160p @ 24Hz
     {"2160p25", 94},   // 3840x2160p @ 25Hz
     {"2160p30", 95},   // 3840x2160p @ 30Hz
-    {"2160p50", 99},   // 4096x2160p @ 50Hz
-    {"2160p60", 100},  // 4096x2160p @ 60Hz
     {"2160p24", 98},   // 4096x2160p @ 24Hz
     {"2160p25", 99},   // 4096x2160p @ 25Hz
     {"2160p30", 100},  // 4096x2160p @ 30Hz
@@ -151,11 +149,14 @@ const VicMapEntry vicMapTable[] = {
     {84, dsTV_RESOLUTION_2160p30},// 4096x2160p @ 30Hz
     {85, dsTV_RESOLUTION_2160p50},// 4096x2160p @ 50Hz
     {86, dsTV_RESOLUTION_2160p60},// 4096x2160p @ 60Hz
-    {92, dsTV_RESOLUTION_2160p24},// 4096x2160p @ 24Hz
-    {93, dsTV_RESOLUTION_2160p25},// 4096x2160p @ 25Hz
-    {94, dsTV_RESOLUTION_2160p30},// 4096x2160p @ 30Hz
-    {95, dsTV_RESOLUTION_2160p50},// 4096x2160p @ 50Hz
-    {96, dsTV_RESOLUTION_2160p60},// 4096x2160p @ 60Hz
+    {93, dsTV_RESOLUTION_2160p24},// 4096x2160p @ 24Hz
+    {94, dsTV_RESOLUTION_2160p25},// 4096x2160p @ 25Hz
+    {95, dsTV_RESOLUTION_2160p30},// 4096x2160p @ 30Hz
+    {98, dsTV_RESOLUTION_2160p24},// 4096x2160p @ 24Hz
+    {99, dsTV_RESOLUTION_2160p25},// 4096x2160p @ 25Hz
+    {100, dsTV_RESOLUTION_2160p30},// 4096x2160p @ 30Hz
+    {101, dsTV_RESOLUTION_2160p50},// 4096x2160p @ 50Hz
+    {102, dsTV_RESOLUTION_2160p60},// 4096x2160p @ 60Hz
 };
 
 #define VIC_MAP_TABLE_SIZE (sizeof(vicMapTable) / sizeof(VicMapEntry))


### PR DESCRIPTION
…ins  resolution which is not common in both the TV and Settop resolutions list

Reason for change: Updating vic table and resolution map Test Procedure: Check get resolution curl commands output Risks:High
Priority: P1