### PR TITLE
RDKEVL-4433: [RPI]Update the README.md files.

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,5 +10,5 @@ LOG.RDK.DSMGR = LOG DEBUG INFO ERROR
 ```
 ### Related Repositories
 
-- **HAL Header Repository**: [rdk-halif-device_settings](https://github.com/rdkcentral/rdk-halif-device_settings) [v2.0.0](https://github.com/rdkcentral/rdk-halif-device_settings/releases/tag/2.0.0)
-- **HAL Test Suite Repository**: [rdk-halif-test-device_settings](https://github.com/rdkcentral/rdk-halif-test-device_settings)
+- **HAL Header Repository**: [rdk-halif-device_settings](https://github.com/rdkcentral/rdk-halif-device_settings) [v6.0.0](https://github.com/rdkcentral/rdk-halif-device_settings/releases/tag/6.0.0)
+- **HAL Test Suite Repository**: [rdk-halif-test-device_settings](https://github.com/rdkcentral/rdk-halif-test-device_settings) [v6.0.0](https://github.com/rdkcentral/rdk-halif-test-device_settings/releases/tag/6.0.0)


### PR DESCRIPTION
Reason for change: Update the README.md files for latest HAL Header Repository tag versions.
Risks: Low.
Signed-off-by: sundaramuneeswaran_muthuraj@comcast.com