### PR TITLE
RDKMVE-2768: Allow the function to pass the L2 color depth test case

### DIFF
--- a/dsVideoPort.c
+++ b/dsVideoPort.c
@@ -111,7 +111,7 @@ static unsigned int getEffectiveOutputColorDepth(void)
         case dsDISPLAY_COLORDEPTH_UNKNOWN:
         default:
             /* AUTO/UNKNOWN falls back to default max bpc request path (10-bit). */
-            return (unsigned int)dsDISPLAY_COLORDEPTH_10BIT;
+            return (unsigned int)dsDISPLAY_COLORDEPTH_AUTO;
     }
 }
 


### PR DESCRIPTION
Reason for change: Allow the function to pass the L2 test case  for colordepth
Test Procedure : Build is successful
Priority : Unprioritized
Risks : None