### PR TITLE
[RDKMVE-2766][VTS][ dsvideodevice l1] Assert Error in few test cases

### DIFF
--- a/dsVideoDevice.c
+++ b/dsVideoDevice.c
@@ -523,17 +523,9 @@ dsError_t dsSetDisplayframerate(intptr_t handle, char *framerate)
 dsError_t dsRegisterFrameratePreChangeCB(dsRegisterFrameratePreChangeCB_t CBFunc)
 {
     hal_info("invoked.\n");
-    if (false == _bVideoDeviceInited) {
-        return dsERR_NOT_INITIALIZED;
-    }
-    if (CBFunc == NULL) {
-        hal_err("Invalid parameter, CBFunc: %p\n", CBFunc);
-        return dsERR_INVALID_PARAM;
-    }
-    pthread_mutex_lock(&_framerateCbMutex);
-    _frameratePreCB = CBFunc;
-    pthread_mutex_unlock(&_framerateCbMutex);
-    return dsERR_NONE;
+    (void)CBFunc;
+    // RPi4 is a source device — framerate change events not applicable. Always return NOT_SUPPORTED.
+    return dsERR_OPERATION_NOT_SUPPORTED;
 }
 
 /**
@@ -562,15 +554,7 @@ dsError_t dsRegisterFrameratePreChangeCB(dsRegisterFrameratePreChangeCB_t CBFunc
 dsError_t dsRegisterFrameratePostChangeCB(dsRegisterFrameratePostChangeCB_t CBFunc)
 {
     hal_info("invoked.\n");
-    if (false == _bVideoDeviceInited) {
-        return dsERR_NOT_INITIALIZED;
-    }
-    if (CBFunc == NULL) {
-        hal_err("Invalid parameter, CBFunc: %p\n", CBFunc);
-        return dsERR_INVALID_PARAM;
-    }
-    pthread_mutex_lock(&_framerateCbMutex);
-    _frameratePostCB = CBFunc;
-    pthread_mutex_unlock(&_framerateCbMutex);
-    return dsERR_NONE;
+    (void)CBFunc;
+    // RPi4 is a source device — framerate change events not applicable. Always return NOT_SUPPORTED.
+    return dsERR_OPERATION_NOT_SUPPORTED;
 }

--- a/dsVideoDeviceSettings.h
+++ b/dsVideoDeviceSettings.h
@@ -38,17 +38,13 @@ extern dsVideoConfig_t  kVideoDeviceConfigs[];
 extern int              kVideoDeviceConfigs_size;
 extern int              kNumVideoDevices;
 #else /* !DS_HAL_EXPORT_CONFIG_SYMBOLS */
-/* Static fallback tables for middleware compile-time dsUTL_DIM(kConfigs). */
-static dsVideoZoom_t kFallbackSupportedDFCs[] DS_SETTINGS_FALLBACK_UNUSED = {
-	dsVIDEO_ZOOM_NONE, dsVIDEO_ZOOM_FULL, dsVIDEO_ZOOM_PLATFORM
-};
 
 #define kNumVideoDevices 1
 
 static dsVideoConfig_t kConfigs[] DS_SETTINGS_FALLBACK_UNUSED = {
 	{
-		dsUTL_DIM(kFallbackSupportedDFCs),
-		kFallbackSupportedDFCs,
+		0,
+		NULL,
 		dsVIDEO_ZOOM_NONE,
 	},
 };

--- a/dsVideoDeviceSettingsData.c
+++ b/dsVideoDeviceSettingsData.c
@@ -30,18 +30,13 @@
 #include "dsTypes.h"
 #include "dsVideoDeviceSettings.h"
 
-/* Supporting arrays - file-local; not exported and not looked up by dlsym */
-static dsVideoZoom_t kSupportedDFCs[] = {
-    dsVIDEO_ZOOM_NONE, dsVIDEO_ZOOM_FULL, dsVIDEO_ZOOM_PLATFORM
-};
-
 /* Exported configuration tables - looked up via dlsym() by the middleware */
 int kNumVideoDevices = 1;
 
 dsVideoConfig_t kVideoDeviceConfigs[] = {
     {
-        /*.numSupportedDFCs = */ dsUTL_DIM(kSupportedDFCs),
-        /*.supportedDFCs = */    kSupportedDFCs,
+        /*.numSupportedDFCs = */ 0,
+        /*.supportedDFCs = */    NULL,
         /*.defaultDFC = */       dsVIDEO_ZOOM_NONE,
     },
 };


### PR DESCRIPTION
Reason: Remove unused DFC support arrays from VideoDevice configuration as RPI has no hardware DFC capability. Source devices return OPERATION_NOT_SUPPORTED for framerate change CB's unconditionally with no other checks.