### PR TITLE
RDKMVE-2374: Fix l2 testcase EnableDisabledVideoPorts

### DIFF
--- a/dsVideoPort.c
+++ b/dsVideoPort.c
@@ -44,6 +44,7 @@
 #include "dshalLogger.h"
 #include "dsVideoPortSettings.h"
 #include "dsVideoDevice.h"
+#define _DEFAULT_SOURCE
 
 /* Forward declarations */
 dsError_t dsGetAudioEncoding(intptr_t handle, dsAudioEncoding_t *encoding);

--- a/dsVideoPort.c
+++ b/dsVideoPort.c
@@ -19,6 +19,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#define _DEFAULT_SOURCE
 #include <string.h>
 #include <stdlib.h>
 #include <stdio.h>
@@ -44,7 +45,6 @@
 #include "dshalLogger.h"
 #include "dsVideoPortSettings.h"
 #include "dsVideoDevice.h"
-#define _DEFAULT_SOURCE
 
 /* Forward declarations */
 dsError_t dsGetAudioEncoding(intptr_t handle, dsAudioEncoding_t *encoding);


### PR DESCRIPTION
Reason for change : Added a header which will usleep needed for EnableDisabledVideoPorts L2 testcase fix
Test Procedure : Build is successful
Priority : Unprioritized
Risks : None