### PR TITLE
REFPLTV-2886 : [VTS][dsDisplay] memcmp() fails due to uninitialized edid1 and edid2 variables.

### DIFF
--- a/dsDisplay.c
+++ b/dsDisplay.c
@@ -1284,6 +1284,13 @@ dsError_t dsGetEDIDBytes(intptr_t handle, unsigned char *edid, int *length)
         return dsERR_INVALID_PARAM;
     }
 
+    bool drmConnected = false, drmEnabled = false;
+    if (!drm_get_hdmi_connector_state(&drmConnected, &drmEnabled) || !drmConnected) {
+        hal_warn("HDMI not connected (DRM), returning empty EDID bytes\n");
+        *length = 0;
+        return dsERR_NONE;
+    }
+
     if (dsInternalGetHdmiEdidBytes(edid, length) != 0 || *length <= 0) {
         hal_err("Failed to get HDMI EDID bytes\n");
         *length = 0;


### PR DESCRIPTION
Reason: dsGetEDIDBytes() was missing a DRM connector state check before attempting to read EDID data. Added the check to return success with empty data when no display is connected.