### PR TITLE
RDKMVE-3011: [VTS][Front Panel] Assert Error in dsSetFPState_neg test  case.

### DIFF
--- a/dsFPD.c
+++ b/dsFPD.c
@@ -1634,7 +1634,7 @@ dsError_t dsSetFPState(dsFPDIndicator_t eIndicator, dsFPDState_t state)
 
 	if (!isIndicatorSupported(eIndicator)) {
 		hal_err("SetFPState rejected: unsupported indicator eIndicator=%d.\n", eIndicator);
-		return dsERR_OPERATION_NOT_SUPPORTED;
+		return dsERR_INVALID_PARAM;
 	}
 
 	FPD_MUTEX_LOCK();


### PR DESCRIPTION
Reason for change: Fix for Assert Error in dsSetFPState_neg test case.
Test Procedure: Build and verify.
Risks: Low.
Signed-off-by: sundaramuneeswaran_muthuraj@comcast.com